### PR TITLE
Fix an accidental strncpy to strncat

### DIFF
--- a/TEST_DIR/OS_Eval.c
+++ b/TEST_DIR/OS_Eval.c
@@ -1003,7 +1003,8 @@ void recv_test(struct timespec *timeArray, int iter, int *i) {
 	struct sockaddr_un server_addr;
 	memset(&server_addr, 0, sizeof(struct sockaddr_un));
 	server_addr.sun_family = AF_UNIX;
-	strncpy(server_addr.sun_path, sock, sizeof(server_addr.sun_path) - 1); 
+	strncpy(server_addr.sun_path, home, sizeof(server_addr.sun_path) - 1); 
+	strncat(server_addr.sun_path, sock, sizeof(server_addr.sun_path) - 1); 
 
 	int forkId = fork();
 

--- a/TEST_DIR/OS_Eval.c
+++ b/TEST_DIR/OS_Eval.c
@@ -903,7 +903,7 @@ void send_test(struct timespec *timeArray, int iter, int *i) {
 	memset(&server_addr, 0, sizeof(struct sockaddr_un));
 	server_addr.sun_family = AF_UNIX;
 	strncpy(server_addr.sun_path, home, sizeof(server_addr.sun_path) - 1); 
-	strncpy(server_addr.sun_path, sock, sizeof(server_addr.sun_path) - 1); 
+	strncat(server_addr.sun_path, sock, sizeof(server_addr.sun_path) - 1); 
 
 	int forkId = fork();
 


### PR DESCRIPTION
- `send_test()`: Fix concat `home` with `sock`, instead of overwiting that in the `sock_addr`. 
- `recv_test()`: fix to the same logic as `send`.