### PR TITLE
README: Use more markdown semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-run "crontab -e" and add the following entries:
+run `crontab -e` and add the following entries:
 
+```
 LEBENCH_DIR=<path>/LEBench/
 PATH=/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 @reboot python <path>/LEBench/run.py >> <path>/LEBench.out 2>&1
+```
 
-run "python get_kern.py" to generate the kernel list
+run `python get_kern.py` to generate the kernel list
 
-run "sudo python run.py"
+run `sudo python run.py`
 
 results will be saved in .csv files in the LEBench folder
 


### PR DESCRIPTION
This commit makes example code and commands to be enclosed with '`'
instead of '"', so that those can be look better on markdown viewers.

Signed-off-by: SeongJae Park <sj38.park@gmail.com>