### PR TITLE
Fix socket path passed to remove()

### DIFF
--- a/TEST_DIR/OS_Eval.c
+++ b/TEST_DIR/OS_Eval.c
@@ -1150,6 +1150,18 @@ enum TEST_NAME parse_testname(const char* testname_str)
     return ALL;
   else if (!strcmp(testname_str, "huge_munmap"))
     return HUGE_MUNMAP;
+  else if (!strcmp(testname_str, "big_munmap"))
+    return BIG_MUNMAP;
+  else if (!strcmp(testname_str, "mid_munmap"))
+    return MID_MUNMAP;
+  else if (!strcmp(testname_str, "small_munmap"))
+    return SMALL_MUNMAP;
+  else if (!strcmp(testname_str, "huge_fork"))
+    return HUGE_FORK;
+  else if (!strcmp(testname_str, "big_fork"))
+    return BIG_FORK;
+  else if (!strcmp(testname_str, "fork"))
+    return FORK;
   else
   {
     printf("Test not implemented\n");

--- a/TEST_DIR/OS_Eval.c
+++ b/TEST_DIR/OS_Eval.c
@@ -933,7 +933,7 @@ void send_test(struct timespec *timeArray, int iter, int *i) {
 
 		read(fds2[0], &r, 1);
 
-		remove(sock);
+		remove(server_addr.sun_path);
 		close(fd_server);
 		close(fd_connect);
 		close(fds1[1]);
@@ -1052,7 +1052,7 @@ void recv_test(struct timespec *timeArray, int iter, int *i) {
 
 		write(fds1[1], &w, 1);
 
-		remove(sock);
+		remove(server_addr.sun_path);
 		close(fd_server);
 		close(fd_connect);
 		close(fds1[1]);

--- a/TEST_DIR/OS_Eval.c
+++ b/TEST_DIR/OS_Eval.c
@@ -278,6 +278,22 @@ void one_line_test(FILE *fp, FILE *copy, void (*f)(struct timespec*), testInfo *
 	}
 	fprintf(fp,"%ld.%09ld,\n",average->tv_sec, average->tv_nsec);
 
+	if (!isFirstIteration)
+  {
+    char ch;
+    while (1)
+    {
+      ch=fgetc(copy);
+      if (ch == '\n')	break;
+      fputc(ch,fp);
+    }
+  } else {
+    fprintf(fp, "%10s", info->name);
+    fprintf(fp, "        sum:,");
+  }
+  fprintf(fp,"%ld.%09ld,\n",sum->tv_sec, sum->tv_nsec);
+
+
 	free(sum);
 	free(average);
 	free(timeArray);

--- a/TEST_DIR/OS_Eval.c
+++ b/TEST_DIR/OS_Eval.c
@@ -88,7 +88,7 @@ struct timespec *calc_diff(struct timespec *smaller, struct timespec *bigger)
 		diff->tv_nsec = 1000000000 + bigger->tv_nsec - smaller->tv_nsec;
 		diff->tv_sec = bigger->tv_sec - 1 - smaller->tv_sec;
 	}
-	else 
+	else
 	{
 		diff->tv_nsec = bigger->tv_nsec - smaller->tv_nsec;
 		diff->tv_sec = bigger->tv_sec - smaller->tv_sec;
@@ -114,50 +114,50 @@ struct timespec* calc_average(struct timespec *sum, int size)
 
 struct timespec *calc_sum(struct timespec ** array, int size)
 {
-	
+
 	struct timespec *sum = (struct timespec *)malloc(sizeof(struct timespec));
 	sum->tv_sec = 0;
 	sum->tv_nsec = 0;
 	for (int i = 0; i < size; i ++)
 	{
-		if (array[i]->tv_nsec >= (1000000000 - sum->tv_nsec)) 
+		if (array[i]->tv_nsec >= (1000000000 - sum->tv_nsec))
 		{
 			sum->tv_sec = sum->tv_sec +1;
 			sum->tv_nsec = array[i]->tv_nsec - (1000000000 - sum->tv_nsec);
 			sum->tv_sec = sum->tv_sec + array[i]->tv_sec;
 		} else {
-		
+
 			sum->tv_nsec = sum->tv_nsec + array[i]->tv_nsec;
 			sum->tv_sec = sum->tv_sec + array[i]->tv_sec;
 		}
-	}	
+	}
 	return sum;
 }
 
 struct timespec *calc_sum2(struct timespec * array, int size)
 {
-	
+
 	struct timespec *sum = (struct timespec *)malloc(sizeof(struct timespec));
 	sum->tv_sec = 0;
 	sum->tv_nsec = 0;
 	for (int i = 0; i < size; i ++)
 	{
-		if (array[i].tv_nsec >= (1000000000 - sum->tv_nsec)) 
+		if (array[i].tv_nsec >= (1000000000 - sum->tv_nsec))
 		{
 			sum->tv_sec = sum->tv_sec +1;
 			sum->tv_nsec = array[i].tv_nsec - (1000000000 - sum->tv_nsec);
 			sum->tv_sec = sum->tv_sec + array[i].tv_sec;
 		} else {
-		
+
 			sum->tv_nsec = sum->tv_nsec + array[i].tv_nsec;
 			sum->tv_sec = sum->tv_sec + array[i].tv_sec;
 		}
-	}	
+	}
 	return sum;
 }
 
 
-int comp(const void *ele1, const void *ele2) 
+int comp(const void *ele1, const void *ele2)
 {
 	struct timespec t1 = *((struct timespec *)ele1);
 	struct timespec t2 = *((struct timespec *)ele2);
@@ -168,7 +168,7 @@ int comp(const void *ele1, const void *ele2)
 		if (t1.tv_nsec > t2.tv_nsec) return 1;
 		else if (t1.tv_nsec == t2.tv_nsec) return 0;
 		else return -1;
-	} 
+	}
 	else {
 		return -1;
 	}
@@ -186,35 +186,35 @@ struct timespec *calc_k_closest(struct timespec *timeArray, int size)
 	if(DEBUG) printf("in calc_k_closest\n");
 	qsort(timeArray, size, sizeof(struct timespec), comp);
 	struct timespec **k_closest = (struct timespec **) malloc (sizeof(struct timespec*) * K);
-	for (int ii = 0; ii < K; ii++) 
+	for (int ii = 0; ii < K; ii++)
 		k_closest[ii] = NULL;
 	struct timespec *prev = &timeArray[0];
 	int j = 0;
 	k_closest[j] = prev;
 	j ++;
-	for (int i = 1; i < size; i ++) 
+	for (int i = 1; i < size; i ++)
 	{
 		struct timespec *curr = &timeArray[i];
-		if(DEBUG) printf("curr %ld.%09ld\n",curr->tv_sec, curr->tv_nsec); 
+		if(DEBUG) printf("curr %ld.%09ld\n",curr->tv_sec, curr->tv_nsec);
 		if (curr->tv_sec != 0 || prev->tv_sec != 0) {
 			if(DEBUG) printf("[warn] test run greater than 1 second: ");
-			if(DEBUG) printf("prev %ld.%09ld, ",prev->tv_sec, prev->tv_nsec); 
-			if(DEBUG) printf("curr %ld.%09ld\n",curr->tv_sec, curr->tv_nsec); 
+			if(DEBUG) printf("prev %ld.%09ld, ",prev->tv_sec, prev->tv_nsec);
+			if(DEBUG) printf("curr %ld.%09ld\n",curr->tv_sec, curr->tv_nsec);
 			j = 0;
 		} else {
 			double diff = curr->tv_nsec - prev->tv_nsec;
 			double ratioDiff = diff/(double)prev->tv_nsec;
 			if(DEBUG) printf("diff: %lf\n", ratioDiff);
 			if (ratioDiff > INPRECISION)
-			{	
+			{
 				j = 0;
-				for (int ii = 0; ii < K; ii++) 
+				for (int ii = 0; ii < K; ii++)
 					k_closest[ii] = NULL;
 			}
-			else 
+			else
 			{
 				k_closest[j] = curr;
-				j ++;	
+				j ++;
 
 			}
 		}
@@ -223,7 +223,7 @@ struct timespec *calc_k_closest(struct timespec *timeArray, int size)
 	}
 	if (DEBUG && j != K) printf("only found the %d closest\n", j);
 	struct timespec* result = k_closest[0];
-	if(DEBUG) printf("result %ld.%09ld\n", result->tv_sec, result->tv_nsec); 
+	if(DEBUG) printf("result %ld.%09ld\n", result->tv_sec, result->tv_nsec);
 	free(k_closest);
 	return result;
 
@@ -245,8 +245,8 @@ void one_line_test(FILE *fp, FILE *copy, void (*f)(struct timespec*), testInfo *
 		(*f)(&timeArray[i]);
 	}
 	struct timespec *sum = calc_sum2(timeArray, runs);
-	struct timespec *average = calc_average(sum, runs);  
-	struct timespec *kbest = calc_k_closest(timeArray, runs);	
+	struct timespec *average = calc_average(sum, runs);
+	struct timespec *kbest = calc_k_closest(timeArray, runs);
 
 	if (!isFirstIteration)
 	{
@@ -261,7 +261,7 @@ void one_line_test(FILE *fp, FILE *copy, void (*f)(struct timespec*), testInfo *
 		fprintf(fp, "%10s", info->name);
 		fprintf(fp, "          kbest:,");
 	}
-	fprintf(fp,"%ld.%09ld,\n",kbest->tv_sec, kbest->tv_nsec); 
+	fprintf(fp,"%ld.%09ld,\n",kbest->tv_sec, kbest->tv_nsec);
 
 	if (!isFirstIteration)
 	{
@@ -276,7 +276,7 @@ void one_line_test(FILE *fp, FILE *copy, void (*f)(struct timespec*), testInfo *
 		fprintf(fp, "%10s", info->name);
 		fprintf(fp, "        average:,");
 	}
-	fprintf(fp,"%ld.%09ld,\n",average->tv_sec, average->tv_nsec); 
+	fprintf(fp,"%ld.%09ld,\n",average->tv_sec, average->tv_nsec);
 
 	free(sum);
 	free(average);
@@ -285,7 +285,7 @@ void one_line_test(FILE *fp, FILE *copy, void (*f)(struct timespec*), testInfo *
 
 	clock_gettime(CLOCK_MONOTONIC,&testEnd);
 	struct timespec *diffTime = calc_diff(&testStart, &testEnd);
-	printf("Test took: %ld.%09ld seconds\n",diffTime->tv_sec, diffTime->tv_nsec); 
+	printf("Test took: %ld.%09ld seconds\n",diffTime->tv_sec, diffTime->tv_nsec);
 	free(diffTime);
 
 	return;
@@ -314,8 +314,8 @@ void one_line_test_v2(FILE *fp, FILE *copy, void (*f)(struct timespec*, int, int
 	}
 
 	struct timespec *sum = calc_sum2(timeArray, runs);
-	struct timespec *average = calc_average(sum, runs);  
-	struct timespec *kbest = calc_k_closest(timeArray, runs);	
+	struct timespec *average = calc_average(sum, runs);
+	struct timespec *kbest = calc_k_closest(timeArray, runs);
 
 	if (!isFirstIteration)
 	{
@@ -330,7 +330,7 @@ void one_line_test_v2(FILE *fp, FILE *copy, void (*f)(struct timespec*, int, int
 		fprintf(fp, "%10s", info->name);
 		fprintf(fp, "          kbest:,");
 	}
-	fprintf(fp,"%ld.%09ld,\n",kbest->tv_sec, kbest->tv_nsec); 
+	fprintf(fp,"%ld.%09ld,\n",kbest->tv_sec, kbest->tv_nsec);
 
 	if (!isFirstIteration)
 	{
@@ -345,7 +345,7 @@ void one_line_test_v2(FILE *fp, FILE *copy, void (*f)(struct timespec*, int, int
 		fprintf(fp, "%10s", info->name);
 		fprintf(fp, "        average:,");
 	}
-	fprintf(fp,"%ld.%09ld,\n",average->tv_sec, average->tv_nsec); 
+	fprintf(fp,"%ld.%09ld,\n",average->tv_sec, average->tv_nsec);
 
 	free(sum);
 	free(average);
@@ -354,7 +354,7 @@ void one_line_test_v2(FILE *fp, FILE *copy, void (*f)(struct timespec*, int, int
 
 	clock_gettime(CLOCK_MONOTONIC,&testEnd);
 	struct timespec *diffTime = calc_diff(&testStart, &testEnd);
-	printf("Test took: %ld.%09ld seconds\n",diffTime->tv_sec, diffTime->tv_nsec); 
+	printf("Test took: %ld.%09ld seconds\n",diffTime->tv_sec, diffTime->tv_nsec);
 	free(diffTime);
 
 	return;
@@ -404,7 +404,7 @@ void two_line_test(FILE *fp, FILE *copy, void (*f)(struct timespec*,struct times
 					break;
 				fputc(ch,fp);
 			}
-			fprintf(fp,"%ld.%09ld,\n",kbests[i]->tv_sec, kbests[i]->tv_nsec); 
+			fprintf(fp,"%ld.%09ld,\n",kbests[i]->tv_sec, kbests[i]->tv_nsec);
 
 			while(1)
 			{
@@ -413,20 +413,20 @@ void two_line_test(FILE *fp, FILE *copy, void (*f)(struct timespec*,struct times
 					break;
 				fputc(ch,fp);
 			}
-			fprintf(fp,"%ld.%09ld,\n",averages[i]->tv_sec,averages[i]->tv_nsec); 
+			fprintf(fp,"%ld.%09ld,\n",averages[i]->tv_sec,averages[i]->tv_nsec);
 		}
 	}
 	else
 	{
 		fprintf(fp, "%10s", info->name);
-		fprintf(fp,"          kbest:,%ld.%09ld,\n",kbests[0]->tv_sec, kbests[0]->tv_nsec); 
+		fprintf(fp,"          kbest:,%ld.%09ld,\n",kbests[0]->tv_sec, kbests[0]->tv_nsec);
 		fprintf(fp, "%10s", info->name);
-		fprintf(fp,"       average:,%ld.%09ld,\n",averages[0]->tv_sec, averages[0]->tv_nsec); 
+		fprintf(fp,"       average:,%ld.%09ld,\n",averages[0]->tv_sec, averages[0]->tv_nsec);
 
 		fprintf(fp, "%10s", info->name);
-		fprintf(fp,"    Child kbest:,%ld.%09ld,\n",kbests[1]->tv_sec, kbests[1]->tv_nsec); 
+		fprintf(fp,"    Child kbest:,%ld.%09ld,\n",kbests[1]->tv_sec, kbests[1]->tv_nsec);
 		fprintf(fp, "%10s", info->name);
-		fprintf(fp," Child average:,%ld.%09ld,\n",averages[1]->tv_sec, averages[1]->tv_nsec); 
+		fprintf(fp," Child average:,%ld.%09ld,\n",averages[1]->tv_sec, averages[1]->tv_nsec);
 	}
 	free(timeArrayChild);
 	free(timeArrayParent);
@@ -439,12 +439,12 @@ void two_line_test(FILE *fp, FILE *copy, void (*f)(struct timespec*,struct times
 
 	clock_gettime(CLOCK_MONOTONIC,&testEnd);
 	struct timespec *diffTime = calc_diff(&testStart, &testEnd);
-	printf("Test took: %ld.%09ld seconds\n",diffTime->tv_sec, diffTime->tv_nsec); 
+	printf("Test took: %ld.%09ld seconds\n",diffTime->tv_sec, diffTime->tv_nsec);
 	free(diffTime);
 	return;
 }
 
-void forkTest(struct timespec *childTime, struct timespec *parentTime) 
+void forkTest(struct timespec *childTime, struct timespec *parentTime)
 {
     struct timespec timeA;
     struct timespec timeC;
@@ -489,7 +489,7 @@ void threadTest(struct timespec *childTime, struct timespec *parentTime)
 
 	add_diff_to_sum(parentTime,timeC,*timeD);
 	add_diff_to_sum(childTime,*timeB,*timeD);
-	
+
 	free(timeB);
 	timeB = NULL;
 	free(timeD);
@@ -508,7 +508,7 @@ void getpid_test(struct timespec *diffTime) {
 }
 
 int file_size = -1;
-void read_test(struct timespec *diffTime) { 
+void read_test(struct timespec *diffTime) {
 	struct timespec startTime, endTime;
 	char *buf_in = (char *) malloc (sizeof(char) * file_size);
 
@@ -518,7 +518,7 @@ void read_test(struct timespec *diffTime) {
 	syscall(SYS_read, fd, buf_in, file_size);
 	clock_gettime(CLOCK_MONOTONIC, &endTime);
 	close(fd);
-	
+
 	add_diff_to_sum(diffTime, endTime, startTime);
 	free(buf_in);
 	return;
@@ -536,13 +536,13 @@ void read_warmup() {
 	if (fd < 0) printf("invalid fd in write: %d\n", fd);
 
 	syscall(SYS_write, fd, buf_out, file_size);
-	close(fd);	
+	close(fd);
 
 	char *buf_in = (char *) malloc (sizeof(char) * file_size);
 
 	fd =open("test_file.txt", O_RDONLY);
 	if (fd < 0) printf("invalid fd in read: %d\n", fd);
-	
+
 	for (int i = 0; i < 1000; i ++) {
 		syscall(SYS_read, fd, buf_in, file_size);
 	}
@@ -566,9 +566,9 @@ void write_test(struct timespec *diffTime) {
 	clock_gettime(CLOCK_MONOTONIC, &startTime);
 	syscall(SYS_write, fd, buf, file_size);
 	clock_gettime(CLOCK_MONOTONIC,&endTime);
-	
+
 	close(fd);
-		
+
 	add_diff_to_sum(diffTime, endTime, startTime);
 	free(buf);
 	return;
@@ -584,7 +584,7 @@ void mmap_test(struct timespec *diffTime) {
 	clock_gettime(CLOCK_MONOTONIC, &startTime);
 	void *addr = (void *)syscall(SYS_mmap, NULL, file_size, PROT_READ, MAP_PRIVATE, fd, 0);
 	clock_gettime(CLOCK_MONOTONIC,&endTime);
-	
+
 	syscall(SYS_munmap, addr, file_size);
         close(fd);
 	add_diff_to_sum(diffTime, endTime, startTime);
@@ -602,7 +602,7 @@ void page_fault_test(struct timespec *diffTime) {
 	clock_gettime(CLOCK_MONOTONIC, &startTime);
 	char a = *((char *)addr);
 	clock_gettime(CLOCK_MONOTONIC,&endTime);
-	
+
 	printf("read: %c\n", a);
 	syscall(SYS_munmap, addr, file_size);
         close(fd);
@@ -630,7 +630,7 @@ void ref_test(struct timespec *diffTime) {
 
 	clock_gettime(CLOCK_MONOTONIC, &startTime);
 	clock_gettime(CLOCK_MONOTONIC,&endTime);
-	
+
 	add_diff_to_sum(diffTime, endTime, startTime);
 	return;
 }
@@ -652,7 +652,7 @@ void munmap_test(struct timespec *diffTime) {
 	return;
 }
 
-int fd_count = -1; 
+int fd_count = -1;
 void select_test(struct timespec *diffTime) {
 	struct timespec startTime, endTime;
 	fd_set rfds;
@@ -706,7 +706,7 @@ void poll_test(struct timespec *diffTime) {
 		name[1] = 'i';
 		name[2] = 'l';
 		name[3] = 'e';
-		int j = i; 
+		int j = i;
 		int index = 4;
 		while (j > 0) {
 			name[index] =  48 + j%10;
@@ -716,7 +716,7 @@ void poll_test(struct timespec *diffTime) {
 		name[index] = '\0';
 		int fd = socket(AF_INET, SOCK_STREAM, 0);
 		if (fd < 0) printf("invalid fd in poll: %d\n", fd);
-		
+
 		pfds[i].fd = fd;
 		pfds[i].events = POLLIN;
 
@@ -753,7 +753,7 @@ void epoll_test(struct timespec *diffTime) {
 		name[1] = 'i';
 		name[2] = 'l';
 		name[3] = 'e';
-		int j = i; 
+		int j = i;
 		int index = 4;
 		while (j > 0) {
 			name[index] =  48 + j%10;
@@ -786,7 +786,7 @@ void epoll_test(struct timespec *diffTime) {
 	if (retval != fd_count) {
 		printf("[error] epoll return unexpected: %d\n", retval);
 	}
-	
+
 	retval = close(epfd);
 	if (retval == -1) printf ("[error] close epfd failed in epoll test %d.\n", epfd);
 	for (int i = 0; i < fd_count; i++) {
@@ -804,7 +804,7 @@ void context_switch_test(struct timespec *diffTime) {
 	if (retval != 0) printf("[error] failed to open pipe1.\n");
 	retval = pipe(fds2);
 	if (retval != 0) printf("[error] failed to open pipe2.\n");
-	
+
 	char w = 'a', r;
 	cpu_set_t cpuset;
 	int prio;
@@ -813,7 +813,7 @@ void context_switch_test(struct timespec *diffTime) {
 	if (retval == -1) printf("[error] failed to get affinity.\n");
 	prio = getpriority(PRIO_PROCESS, 0);
 	if (prio == -1) printf("[error] failed to get priority.\n");
-	
+
 	int forkId = fork();
 	if (forkId > 0) { // is parent
 		retval = close(fds1[0]);
@@ -826,26 +826,26 @@ void context_switch_test(struct timespec *diffTime) {
 		CPU_SET(0, &set);
 		retval = sched_setaffinity(getpid(), sizeof(set), &set);
 		if (retval == -1) printf("[error] failed to set processor affinity.\n");
-		retval = setpriority(PRIO_PROCESS, 0, -20); 
+		retval = setpriority(PRIO_PROCESS, 0, -20);
 		if (retval == -1) printf("[error] failed to set process priority.\n");
 
-		read(fds2[0], &r, 1); 		
+		read(fds2[0], &r, 1);
 
 		clock_gettime(CLOCK_MONOTONIC, &startTime);
 		for (int i = 0; i < iter; i++) {
-			write(fds1[1], &w, 1);		
-			read(fds2[0], &r, 1); 
+			write(fds1[1], &w, 1);
+			read(fds2[0], &r, 1);
 		}
 		clock_gettime(CLOCK_MONOTONIC, &endTime);
 		int status;
         	wait(&status);
-		
+
 		close(fds1[1]);
 		close(fds2[0]);
 
 
 	} else if (forkId == 0){
-	
+
 		retval = close(fds1[1]);
 		if (retval != 0) printf("[error] failed to close fd1.\n");
 		retval = close(fds2[0]);
@@ -856,15 +856,15 @@ void context_switch_test(struct timespec *diffTime) {
 		CPU_SET(0, &set);
 		retval = sched_setaffinity(getpid(), sizeof(set), &set);
 		if (retval == -1) printf("[error] failed to set processor affinity.\n");
-		retval = setpriority(PRIO_PROCESS, 0, -20); 
+		retval = setpriority(PRIO_PROCESS, 0, -20);
 		if (retval == -1) printf("[error] failed to set process priority.\n");
 
-		write(fds2[1], &w, 1);		
+		write(fds2[1], &w, 1);
 		for (int i = 0; i < iter; i++) {
-			read(fds1[0], &r, 1);		
-			write(fds2[1], &w, 1);		
+			read(fds1[0], &r, 1);
+			write(fds2[1], &w, 1);
 		}
-			
+
         	kill(getpid(), SIGINT);
 		printf("[error] unable to kill child process\n");
 		return;
@@ -897,13 +897,13 @@ void send_test(struct timespec *timeArray, int iter, int *i) {
 	if (retval != 0) printf("[error] failed to open pipe1.\n");
 	retval = pipe(fds2);
 	if (retval != 0) printf("[error] failed to open pipe1.\n");
-	char w = 'b', r;	
-	
+	char w = 'b', r;
+
 	struct sockaddr_un server_addr;
 	memset(&server_addr, 0, sizeof(struct sockaddr_un));
 	server_addr.sun_family = AF_UNIX;
-	strncpy(server_addr.sun_path, home, sizeof(server_addr.sun_path) - 1); 
-	strncat(server_addr.sun_path, sock, sizeof(server_addr.sun_path) - 1); 
+	strncpy(server_addr.sun_path, home, sizeof(server_addr.sun_path) - 1);
+	strncat(server_addr.sun_path, sock, sizeof(server_addr.sun_path) - 1);
 
 	int forkId = fork();
 
@@ -918,10 +918,10 @@ void send_test(struct timespec *timeArray, int iter, int *i) {
 
 		int fd_server = socket(AF_UNIX, SOCK_STREAM, 0);
 		if (fd_server < 0) printf("[error] failed to open server socket.\n");
-	
+
 		retval = bind(fd_server, (struct sockaddr *) &server_addr, sizeof(struct sockaddr_un));
 		if (retval == -1) printf("[error] failed to bind.\n");
-		retval = listen(fd_server, 10); 
+		retval = listen(fd_server, 10);
 		if (retval == -1) printf("[error] failed to listen.\n");
 		if (DEBUG) printf("Waiting for connection\n");
 
@@ -960,10 +960,10 @@ void send_test(struct timespec *timeArray, int iter, int *i) {
 		for (int i = 0; i < msg_size; i++) {
 			buf[i] = 'a';
 		}
-		
+
 		retval = send(fd_client, buf, msg_size, MSG_DONTWAIT);
-		for (int j = 0; *i < iter & j < curr_iter_limit; (*i) ++, j++) {	
-			
+		for (int j = 0; *i < iter & j < curr_iter_limit; (*i) ++, j++) {
+
 			clock_gettime(CLOCK_MONOTONIC,&startTime);
 			retval = syscall(SYS_sendto, fd_client, buf, msg_size, MSG_DONTWAIT, NULL, 0);
 			clock_gettime(CLOCK_MONOTONIC,&endTime);
@@ -975,9 +975,9 @@ void send_test(struct timespec *timeArray, int iter, int *i) {
 		}
 
 		write(fds2[1], &w, 1);
-		close(fd_client);	
-		close(fds1[0]);	
-		close(fds2[1]);	
+		close(fd_client);
+		close(fds1[0]);
+		close(fds2[1]);
 		free(buf);
 		int status;
         	wait(&status);
@@ -996,13 +996,13 @@ void recv_test(struct timespec *timeArray, int iter, int *i) {
 	if (retval != 0) {
 		printf("[error] failed to open pipe2.\n");
 	}
-	char w = 'b', r;	
-	
+	char w = 'b', r;
+
 	struct sockaddr_un server_addr;
 	memset(&server_addr, 0, sizeof(struct sockaddr_un));
 	server_addr.sun_family = AF_UNIX;
-	strncpy(server_addr.sun_path, home, sizeof(server_addr.sun_path) - 1); 
-	strncat(server_addr.sun_path, sock, sizeof(server_addr.sun_path) - 1); 
+	strncpy(server_addr.sun_path, home, sizeof(server_addr.sun_path) - 1);
+	strncat(server_addr.sun_path, sock, sizeof(server_addr.sun_path) - 1);
 
 	int forkId = fork();
 
@@ -1017,7 +1017,7 @@ void recv_test(struct timespec *timeArray, int iter, int *i) {
 
 		int fd_server = socket(AF_UNIX, SOCK_STREAM, 0);
 		if (fd_server < 0) printf("[error] failed to open server socket.\n");
-	
+
 		retval = bind(fd_server, (struct sockaddr *) &server_addr, sizeof(struct sockaddr_un));
 		if (retval == -1) printf("[error] failed to bind.\n");
 		retval = listen(fd_server, 10);
@@ -1034,11 +1034,11 @@ void recv_test(struct timespec *timeArray, int iter, int *i) {
 
 
 		char *buf = (char *) malloc (sizeof(char) * msg_size);
-		
+
 		struct timespec startTime, endTime;
 		retval = recv(fd_connect, buf, msg_size, MSG_DONTWAIT);
-		for (int j = 0; *i < iter & j < curr_iter_limit; (*i) ++, j++) {	
-			
+		for (int j = 0; *i < iter & j < curr_iter_limit; (*i) ++, j++) {
+
 			clock_gettime(CLOCK_MONOTONIC,&startTime);
 			retval = syscall(SYS_recvfrom, fd_connect, buf, msg_size, MSG_DONTWAIT, NULL, NULL);
 			clock_gettime(CLOCK_MONOTONIC,&endTime);
@@ -1076,9 +1076,9 @@ void recv_test(struct timespec *timeArray, int iter, int *i) {
 		for (int i = 0; i < msg_size; i++) {
 			buf[i] = 'a';
 		}
-		
-		for (int j = 0; j < curr_iter_limit + 1; (*i) ++, j++) {	
-			
+
+		for (int j = 0; j < curr_iter_limit + 1; (*i) ++, j++) {
+
 			retval = syscall(SYS_sendto, fd_client, buf, msg_size, MSG_DONTWAIT, NULL, 0);
 
 			if (retval == -1) {
@@ -1088,9 +1088,9 @@ void recv_test(struct timespec *timeArray, int iter, int *i) {
 
 		write(fds2[1], &w, 1);
 		read(fds1[0], &r, 1);
-		close(fd_client);	
-		close(fds1[0]);	
-		close(fds2[1]);	
+		close(fd_client);
+		close(fds1[0]);
+		close(fds2[1]);
 		free(buf);
 
         	kill(getpid(),SIGINT);
@@ -1101,10 +1101,66 @@ void recv_test(struct timespec *timeArray, int iter, int *i) {
 
 }
 
+enum TEST_NAME
+{
+  ALL,
+  REF,
+  CPU,
+  GETPID,
+  CONTEXT_SWITCH,
+  SEND,
+  RECV,
+  BIG_SEND,
+  BIG_RECV,
+  FORK,
+  THREAD_CREATE,
+  BIG_FORK,
+  HUGE_FORK,
+  SMALL_WRITE,
+  SMALL_READ,
+  SMALL_MMAP,
+  SMALL_MUNMAP,
+  SMALL_PAGEFAULT,
+  MID_WRITE,
+  MID_READ,
+  MID_MMAP,
+  MID_MUNMAP,
+  MID_PAGEFAULT,
+  BIG_WRITE,
+  BIG_READ,
+  BIG_MMAP,
+  BIG_MUNMAP,
+  BIG_PAGEFAULT,
+  HUGE_WRITE,
+  HUGE_READ,
+  HUGE_MMAP,
+  HUGE_MUNMAP,
+  HUGE_PAGEFAULT,
+  SELECT,
+  POLL,
+  EPOLL,
+  SELECT_BIG,
+  POLL_BIG,
+  EPOLL_BIG
+};
+
+enum TEST_NAME parse_testname(const char* testname_str)
+{
+  if (!strcmp(testname_str, "all"))
+    return ALL;
+  else if (!strcmp(testname_str, "huge_munmap"))
+    return HUGE_MUNMAP;
+  else
+  {
+    printf("Test not implemented\n");
+    exit(1);
+  }
+}
+
 int main(int argc, char *argv[])
 {
 	home = getenv("LEBENCH_DIR");
-	
+
 	output_fn = (char *)malloc(500*sizeof(char));
 	strcpy(output_fn, home);
 	strcat(output_fn, OUTPUT_FN);
@@ -1115,12 +1171,15 @@ int main(int argc, char *argv[])
 
 	struct timespec startTime, endTime;
 	clock_gettime(CLOCK_MONOTONIC, &startTime);
-	if (argc != 3){printf("Invalid arguments, gave %d not 3",argc);return(0);}
+	if (argc != 4){printf("Invalid arguments, gave %d not 4",argc);return(0);}
 	char *iteration = argv[1];
 	char *str_os_name = argv[2];
+  char *testname_str = argv[3];
 	FILE *fp;
 	FILE *copy = NULL;
+  enum TEST_NAME test_name = parse_testname(testname_str);
 	fp=fopen(new_output_fn,"w");
+  
 	isFirstIteration = false;
 	if (*iteration == '0'){isFirstIteration = true;}
 	if (!isFirstIteration)
@@ -1147,76 +1206,114 @@ int main(int argc, char *argv[])
 		fprintf(fp, "OS Benchmark experiment\nTest Name:,");
 	}
 	fprintf(fp,"%s,\n",str_os_name);
-	
-	testInfo info;	
+
+	testInfo info;
 
 	/*****************************************/
 	/*               GETPID                  */
 	/*****************************************/
 
 	sleep(60);
-	info.iter = BASE_ITER * 100;
-	info.name = "ref";
-	one_line_test(fp, copy, ref_test, &info);
 
-	info.iter = 100;
-	info.name = "cpu";
-	one_line_test(fp, copy, cpu_test, &info);
-
-
-	info.iter = BASE_ITER * 100;
-	info.name = "getpid";
-	one_line_test(fp, copy, getpid_test, &info);
+  if (test_name == ALL || test_name == REF)
+  {
+	  info.iter = BASE_ITER * 100;
+	  info.name = "ref";
+	  one_line_test(fp, copy, ref_test, &info);
+  }
 
 
-	
+  if (test_name == ALL || test_name == CPU)
+  {
+	  info.iter = 100;
+	  info.name = "cpu";
+	  one_line_test(fp, copy, cpu_test, &info);
+  }
+
+
+  if (test_name == ALL || test_name == GETPID)
+  {
+	  info.iter = BASE_ITER * 100;
+	  info.name = "getpid";
+	  one_line_test(fp, copy, getpid_test, &info);
+  }
+
+
+
+
 	/*****************************************/
 	/*            CONTEXT SWITCH             */
 	/*****************************************/
-	info.iter = BASE_ITER * 10;
-	info.name = "context siwtch";
-	one_line_test(fp, copy, context_switch_test, &info);
+
+  if (test_name == ALL || test_name == CONTEXT_SWITCH)
+  {
+	  info.iter = BASE_ITER * 10;
+	  info.name = "context siwtch";
+	  one_line_test(fp, copy, context_switch_test, &info);
+  }
 
 
 	/*****************************************/
 	/*             SEND & RECV               */
 	/*****************************************/
-	msg_size = 1;	
+	msg_size = 1;
 	curr_iter_limit = 50;
 	printf("msg size: %d.\n", msg_size);
 	printf("curr iter limit: %d.\n", curr_iter_limit);
-	info.iter = BASE_ITER * 10;
-	info.name = "send";
-	one_line_test_v2(fp, copy, send_test, &info);
-	
-	info.iter = BASE_ITER * 10;
-	info.name = "recv";
-	one_line_test_v2(fp, copy, recv_test, &info);
-	
+
+  if (test_name == ALL || test_name == SEND)
+  {
+	  info.iter = BASE_ITER * 10;
+	  info.name = "send";
+	  one_line_test_v2(fp, copy, send_test, &info);
+  }
+
+  if (test_name == ALL || test_name == RECV)
+  {
+	  info.iter = BASE_ITER * 10;
+	  info.name = "recv";
+	  one_line_test_v2(fp, copy, recv_test, &info);
+  }
+
 
 	msg_size = 96000;	// This size 96000 would cause blocking on older kernels!
 	curr_iter_limit = 1;
 	printf("msg size: %d.\n", msg_size);
 	printf("curr iter limit: %d.\n", curr_iter_limit);
-	info.iter = BASE_ITER;
-	info.name = "big send";
-	one_line_test_v2(fp, copy, send_test, &info);
-		
-	info.iter = BASE_ITER;
-	info.name = "big recv";
-	one_line_test_v2(fp, copy, recv_test, &info);
-	
+
+  if (test_name == ALL || test_name == BIG_SEND)
+  {
+	  info.iter = BASE_ITER;
+	  info.name = "big send";
+	  one_line_test_v2(fp, copy, send_test, &info);
+  }
+
+
+  if (test_name == ALL || test_name == BIG_RECV)
+  {
+	  info.iter = BASE_ITER;
+	  info.name = "big recv";
+	  one_line_test_v2(fp, copy, recv_test, &info);
+  }
+
 
 	/*****************************************/
 	/*         FORK & THREAD CREATE          */
 	/*****************************************/
-	info.iter = BASE_ITER * 2;
-	info.name = "fork";
-	two_line_test(fp, copy, forkTest, &info);
-	
-	info.iter = BASE_ITER * 5;
-	info.name = "thr create";
-	two_line_test(fp, copy, threadTest, &info);
+
+  if (test_name == ALL || test_name == FORK)
+  {
+	  info.iter = BASE_ITER * 2;
+	  info.name = "fork";
+	  two_line_test(fp, copy, forkTest, &info);
+  }
+
+  if (test_name == ALL || test_name == THREAD_CREATE)
+  {
+	  info.iter = BASE_ITER * 5;
+	  info.name = "thr create";
+	  two_line_test(fp, copy, threadTest, &info);
+  }
 
 
 	int page_count = 6000;
@@ -1224,10 +1321,13 @@ int main(int argc, char *argv[])
 	for (int i = 0; i < page_count; i++) {
     		pages[i] = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
 	}
-	
-	info.iter = BASE_ITER / 2;	
-	info.name = "big fork";
-	two_line_test(fp, copy, forkTest, &info);
+
+  if (test_name == ALL || test_name == BIG_FORK)
+  {
+	  info.iter = BASE_ITER / 2;
+	  info.name = "big fork";
+	  two_line_test(fp, copy, forkTest, &info);
+  }
 
 	for (int i = 0; i < page_count; i++) {
 		munmap(pages[i], PAGE_SIZE);
@@ -1239,10 +1339,13 @@ int main(int argc, char *argv[])
 	for (int i = 0; i < page_count; i++) {
     		pages1[i] = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
 	}
-	
-	info.iter = BASE_ITER / 2;	
-	info.name = "huge fork";
-	two_line_test(fp, copy, forkTest, &info);
+
+  if (test_name == ALL || test_name == HUGE_FORK)
+  {
+	  info.iter = BASE_ITER / 2;
+	  info.name = "huge fork";
+	  two_line_test(fp, copy, forkTest, &info);
+  }
 
 	for (int i = 0; i < page_count; i++) {
 		munmap(pages1[i], PAGE_SIZE);
@@ -1254,103 +1357,163 @@ int main(int argc, char *argv[])
 	/*****************************************/
 
 	/****** SMALL ******/
-	file_size = PAGE_SIZE;	
+	file_size = PAGE_SIZE;
 	printf("file size: %d.\n", file_size);
 
-	info.iter = BASE_ITER * 10;
-	info.name = "small write";
-	one_line_test(fp, copy, write_test, &info);
-      
-	info.iter = BASE_ITER * 10; 
-	info.name = "small read";
-	read_warmup();
-	one_line_test(fp, copy, read_test, &info);
-	
-	info.iter = BASE_ITER * 10;
-	info.name = "small mmap";
-	one_line_test(fp, copy, mmap_test, &info);
-	
-	info.iter = BASE_ITER * 10;
-	info.name = "small munmap";
-	one_line_test(fp, copy, munmap_test, &info);
+  if (test_name == ALL || test_name == SMALL_WRITE)
+  {
+	  info.iter = BASE_ITER * 10;
+	  info.name = "small write";
+	  one_line_test(fp, copy, write_test, &info);
+  }
 
-	info.iter = BASE_ITER * 5;
-	info.name = "small page fault";
-	one_line_test(fp, copy, page_fault_test, &info);
+  if (test_name == ALL || test_name == SMALL_READ)
+  {
+	  info.iter = BASE_ITER * 10;
+	  info.name = "small read";
+	  read_warmup();
+	  one_line_test(fp, copy, read_test, &info);
+  }
+
+  if (test_name == ALL || test_name == SMALL_MMAP)
+  {
+	  info.iter = BASE_ITER * 10;
+	  info.name = "small mmap";
+	  one_line_test(fp, copy, mmap_test, &info);
+  }
+
+  if (test_name == ALL || test_name == SMALL_MUNMAP)
+  {
+	  info.iter = BASE_ITER * 10;
+	  info.name = "small munmap";
+	  one_line_test(fp, copy, munmap_test, &info);
+  }
+
+  if (test_name == ALL || test_name == SMALL_PAGEFAULT)
+  {
+	  info.iter = BASE_ITER * 5;
+	  info.name = "small page fault";
+	  one_line_test(fp, copy, page_fault_test, &info);
+  }
 
 	/****** MID ******/
 	file_size = PAGE_SIZE * 10;
 	printf("file size: %d.\n", file_size);
 
-	info.iter = BASE_ITER * 10;
-	info.name = "mid write";
-	one_line_test(fp, copy, write_test, &info);
-	
-	info.iter = BASE_ITER * 10;
-	info.name = "mid read";
-	read_warmup();
-	one_line_test(fp, copy, read_test, &info);
+  if (test_name == ALL || test_name == MID_WRITE)
+  {
+	  info.iter = BASE_ITER * 10;
+	  info.name = "mid write";
+	  one_line_test(fp, copy, write_test, &info);
+  }
 
-	info.iter = BASE_ITER * 10;
-	info.name = "mid mmap";
-	one_line_test(fp, copy, mmap_test, &info);
-	
-	info.iter = BASE_ITER * 10;
-	info.name = "mid munmap";
-	one_line_test(fp, copy, munmap_test, &info);
+  if (test_name == ALL || test_name == MID_READ)
+  {
+	  info.iter = BASE_ITER * 10;
+	  info.name = "mid read";
+	  read_warmup();
+	  one_line_test(fp, copy, read_test, &info);
+  }
 
-	info.iter = BASE_ITER * 5;
-	info.name = "mid page fault";
-	one_line_test(fp, copy, page_fault_test, &info);
+  if (test_name == ALL || test_name == MID_MMAP)
+  {
+	  info.iter = BASE_ITER * 10;
+	  info.name = "mid mmap";
+	  one_line_test(fp, copy, mmap_test, &info);
+  }
+
+  if (test_name == ALL || test_name == MID_MUNMAP)
+  {
+	  info.iter = BASE_ITER * 10;
+	  info.name = "mid munmap";
+	  one_line_test(fp, copy, munmap_test, &info);
+  }
+
+  if (test_name == ALL || test_name == MID_PAGEFAULT)
+  {
+	  info.iter = BASE_ITER * 5;
+	  info.name = "mid page fault";
+	  one_line_test(fp, copy, page_fault_test, &info);
+  }
 
 	/****** BIG ******/
-	file_size = PAGE_SIZE * 1000;	
+	file_size = PAGE_SIZE * 1000;
 	printf("file size: %d.\n", file_size);
 
-	info.iter = BASE_ITER / 2;
-	info.name = "big write";
-	one_line_test(fp, copy, write_test, &info);
-	
-	info.iter = BASE_ITER;
-	info.name = "big read";
-	read_warmup();
-	one_line_test(fp, copy, read_test, &info);
-	
-	info.iter = BASE_ITER * 10;
-	info.name = "big mmap";
-	one_line_test(fp, copy, mmap_test, &info);
-	
-	info.iter = BASE_ITER / 4;
-	info.name = "big munmap";
-	one_line_test(fp, copy, munmap_test, &info);
-	
-	info.iter = BASE_ITER * 5;
-	info.name = "big page fault";
-	one_line_test(fp, copy, page_fault_test, &info);
+  if (test_name == ALL || test_name == BIG_WRITE)
+  {
+	  info.iter = BASE_ITER / 2;
+	  info.name = "big write";
+	  one_line_test(fp, copy, write_test, &info);
+  }
+
+  if (test_name == ALL || test_name == BIG_READ)
+  {
+	  info.iter = BASE_ITER;
+	  info.name = "big read";
+	  read_warmup();
+	  one_line_test(fp, copy, read_test, &info);
+  }
+
+  if (test_name == ALL || test_name == BIG_MMAP)
+  {
+	  info.iter = BASE_ITER * 10;
+	  info.name = "big mmap";
+	  one_line_test(fp, copy, mmap_test, &info);
+  }
+
+  if (test_name == ALL || test_name == BIG_MUNMAP)
+  {
+	  info.iter = BASE_ITER / 4;
+	  info.name = "big munmap";
+	  one_line_test(fp, copy, munmap_test, &info);
+  }
+
+  if (test_name == ALL || test_name == BIG_PAGEFAULT)
+  {
+	  info.iter = BASE_ITER * 5;
+	  info.name = "big page fault";
+	  one_line_test(fp, copy, page_fault_test, &info);
+  }
 
        /****** HUGE ******/
-	file_size = PAGE_SIZE * 10000;	
+	file_size = PAGE_SIZE * 10000;
 	printf("file size: %d.\n", file_size);
 
-	info.iter = BASE_ITER / 4;
-	info.name = "huge write";
-	one_line_test(fp, copy, write_test, &info);
+  if (test_name == ALL || test_name == HUGE_WRITE)
+  {
+	  info.iter = BASE_ITER / 4;
+	  info.name = "huge write";
+	  one_line_test(fp, copy, write_test, &info);
+  }
 
-	info.iter = BASE_ITER;
-	info.name = "huge read";
-	one_line_test(fp, copy, read_test, &info);
-	
-	info.iter = BASE_ITER * 10;
-	info.name = "huge mmap";
-	one_line_test(fp, copy, mmap_test, &info);
-	
-	info.iter = BASE_ITER / 4; 
-	info.name = "huge munmap";
-	one_line_test(fp, copy, munmap_test, &info);
+  if (test_name == ALL || test_name == HUGE_READ)
+  {
+	  info.iter = BASE_ITER;
+	  info.name = "huge read";
+	  one_line_test(fp, copy, read_test, &info);
+  }
 
-	info.iter = BASE_ITER * 5;
-	info.name = "huge page fault";
-	one_line_test(fp, copy, page_fault_test, &info);
+  if (test_name == ALL || test_name == HUGE_MMAP)
+  {
+	  info.iter = BASE_ITER * 10;
+	  info.name = "huge mmap";
+	  one_line_test(fp, copy, mmap_test, &info);
+  }
+
+  if (test_name == ALL || test_name == HUGE_MUNMAP)
+  {
+	  info.iter = BASE_ITER / 4;
+	  info.name = "huge munmap";
+	  one_line_test(fp, copy, munmap_test, &info);
+  }
+
+  if (test_name == ALL || test_name == HUGE_PAGEFAULT)
+  {
+	  info.iter = BASE_ITER * 5;
+	  info.name = "huge page fault";
+	  one_line_test(fp, copy, page_fault_test, &info);
+  }
 
 	/*****************************************/
 	/*              WRITE & READ             */
@@ -1359,33 +1522,54 @@ int main(int argc, char *argv[])
 	/****** SMALL ******/
 	fd_count = 10;
 
-	info.iter = BASE_ITER * 10;
-	info.name = "select";
-	one_line_test(fp, copy, select_test, &info);
-	
-	info.iter = BASE_ITER * 10;
-	info.name = "poll";
-	one_line_test(fp, copy, poll_test, &info);
-		
-	info.iter = BASE_ITER * 10;
-	info.name = "epoll";
-	one_line_test(fp, copy, epoll_test, &info);
-	
+  if (test_name == ALL || test_name == SELECT)
+  {
+	  info.iter = BASE_ITER * 10;
+	  info.name = "select";
+	  one_line_test(fp, copy, select_test, &info);
+  }
+
+  if (test_name == ALL || test_name == POLL)
+  {
+	  info.iter = BASE_ITER * 10;
+	  info.name = "poll";
+	  one_line_test(fp, copy, poll_test, &info);
+  }
+
+
+  if (test_name == ALL || test_name == EPOLL)
+  {
+	  info.iter = BASE_ITER * 10;
+	  info.name = "epoll";
+	  one_line_test(fp, copy, epoll_test, &info);
+  }
+
 
 	/****** BIG ******/
 	fd_count = 1000;
 
-	info.iter = BASE_ITER;
-	info.name = "select big";
-	one_line_test(fp, copy, select_test, &info);
+  if (test_name == ALL || test_name == SELECT_BIG)
+  {
+	  info.iter = BASE_ITER;
+	  info.name = "select big";
+	  one_line_test(fp, copy, select_test, &info);
+  }
 
-	info.iter = BASE_ITER;
-	info.name = "poll big";
-	one_line_test(fp, copy, poll_test, &info);
 
-	info.iter = BASE_ITER;
-	info.name = "epoll big";
-	one_line_test(fp, copy, epoll_test, &info);
+  if (test_name == ALL || test_name == POLL_BIG)
+  {
+	  info.iter = BASE_ITER;
+	  info.name = "poll big";
+	  one_line_test(fp, copy, poll_test, &info);
+  }
+
+
+  if (test_name == ALL || test_name == EPOLL_BIG)
+  {
+	  info.iter = BASE_ITER;
+	  info.name = "epoll big";
+	  one_line_test(fp, copy, epoll_test, &info);
+  }
 
 	fclose(fp);
 	if (!isFirstIteration)
@@ -1403,7 +1587,7 @@ int main(int argc, char *argv[])
 	int ret = rename(new_output_fn,name);
 	clock_gettime(CLOCK_MONOTONIC, &endTime);
 	struct timespec *diffTime = calc_diff(&startTime, &endTime);
-	printf("Test took: %ld.%09ld seconds\n",diffTime->tv_sec, diffTime->tv_nsec); 
+	printf("Test took: %ld.%09ld seconds\n",diffTime->tv_sec, diffTime->tv_nsec);
 	free(diffTime);
 	return(0);
 }


### PR DESCRIPTION
Incorrect path is passed to `remove()` in send_test and recv_test which results in the socket not getting removed and results in `bind()` faliure with error messages like '_Address already in use'_ on some systems.

This PR addresses the issue by using the concatenated path stored inside server_addr.sun_path

`send_test()` : Replace remove(sock) with remove(server_addr.sun_path) 
`recv_test()` : Fix to the same logic as send